### PR TITLE
fix nullpoint bugs

### DIFF
--- a/src/main/java/com/verdantartifice/thaumicwonders/common/registry/InfusionEnchantmentsTW.java
+++ b/src/main/java/com/verdantartifice/thaumicwonders/common/registry/InfusionEnchantmentsTW.java
@@ -5,6 +5,7 @@ import com.verdantartifice.thaumicwonders.common.effects.PotionsTW;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 import net.minecraft.potion.PotionEffect;
+import net.minecraft.util.EnumHand;
 import net.minecraftforge.common.util.EnumHelper;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
 import thaumcraft.common.lib.enchantment.EnumInfusionEnchantment;
@@ -22,8 +23,10 @@ public class InfusionEnchantmentsTW {
         if (event.getSource().getTrueSource() instanceof EntityLivingBase) {
             EntityLivingBase source = (EntityLivingBase) event.getSource().getTrueSource();
             EntityLivingBase target = event.getEntityLiving();
-            ItemStack heldStack = source.getHeldItem(source.getActiveHand());
-            int rank = EnumInfusionEnchantment.getInfusionEnchantmentLevel(heldStack, VOIDFLAME);
+            // 某些情况下 getActiveHand 可能为 null，直接查询主/副手可避免 NPE/IAE
+            int rankMain = EnumInfusionEnchantment.getInfusionEnchantmentLevel(source.getHeldItem(EnumHand.MAIN_HAND), VOIDFLAME);
+            int rankOff = EnumInfusionEnchantment.getInfusionEnchantmentLevel(source.getHeldItem(EnumHand.OFF_HAND), VOIDFLAME);
+            int rank = Math.max(rankMain, rankOff);
             if (rank > 0) {
                 target.addPotionEffect(new PotionEffect(PotionsTW.VOIDFLAME, 60 + 60 * rank, 1, true, false));
             }

--- a/src/main/java/com/verdantartifice/thaumicwonders/common/registry/InfusionEnchantmentsTW.java
+++ b/src/main/java/com/verdantartifice/thaumicwonders/common/registry/InfusionEnchantmentsTW.java
@@ -23,7 +23,6 @@ public class InfusionEnchantmentsTW {
         if (event.getSource().getTrueSource() instanceof EntityLivingBase) {
             EntityLivingBase source = (EntityLivingBase) event.getSource().getTrueSource();
             EntityLivingBase target = event.getEntityLiving();
-            // 某些情况下 getActiveHand 可能为 null，直接查询主/副手可避免 NPE/IAE
             int rankMain = EnumInfusionEnchantment.getInfusionEnchantmentLevel(source.getHeldItem(EnumHand.MAIN_HAND), VOIDFLAME);
             int rankOff = EnumInfusionEnchantment.getInfusionEnchantmentLevel(source.getHeldItem(EnumHand.OFF_HAND), VOIDFLAME);
             int rank = Math.max(rankMain, rankOff);


### PR DESCRIPTION
---- Minecraft Crash Report ----
// Lolis deobfuscated this stacktrace using MCP's stable-39 mappings.
// Would you like a cupcake?

Time: 2025-08-29 13:59:37 CST
Description: Unexpected error

java.lang.IllegalArgumentException: Invalid hand null
    at net.minecraft.entity.EntityLivingBase.getHeldItem(EntityLivingBase.java:1640)
    at com.verdantartifice.thaumicwonders.common.registry.InfusionEnchantmentsTW.handleVoidflameAttack(InfusionEnchantmentsTW.java:25)
    at com.verdantartifice.thaumicwonders.common.events.EntityEvents.entityHurt(EntityEvents.java:29)
    at net.minecraftforge.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:78)
    at net.minecraftforge.fml.common.eventhandler.EventBus.post(EventBus.java:212)
    at net.minecraftforge.common.ForgeHooks.onLivingHurt(ForgeHooks.java:609)
    at net.minecraft.entity.EntityLivingBase.damageEntity(EntityLivingBase.java:1410)
    at com.dainxt.dungeonsmod.entity.boss.EntitySun.attackEntityFrom(EntitySun.java:96)
    at slimeknights.tconstruct.library.tools.ToolCore.dealDamage(ToolCore.java:148)
    at slimeknights.tconstruct.tools.melee.item.BroadSword.dealDamage(BroadSword.java:47)
    at slimeknights.tconstruct.library.utils.ToolHelper.attackEntity(ToolHelper.java:733)
    at slimeknights.tconstruct.library.utils.ToolHelper.attackEntity(ToolHelper.java:616)
    at slimeknights.tconstruct.library.tools.ToolCore.onLeftClickEntity(ToolCore.java:236)
    at net.minecraftforge.common.ForgeHooks.onPlayerAttackTarget(ForgeHooks.java:1078)
    at net.minecraft.entity.player.EntityPlayer.attackTargetEntityWithCurrentItem(EntityPlayer.java:1250)
    at bettercombat.mod.client.handler.EventHandlersClient.onMouseLeftClick(EventHandlersClient.java:107)
    at bettercombat.mod.client.handler.EventHandlersClient.onMouseEvent(EventHandlersClient.java:49)
    at net.minecraftforge.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:78)
    at net.minecraftforge.fml.common.eventhandler.EventBus.post(EventBus.java:212)
    at net.minecraftforge.client.ForgeHooksClient.postMouseEvent(ForgeHooksClient.java:260)
    at net.minecraft.client.Minecraft.runTickMouse(MinecraftAccessor.java:2259)
    at net.minecraft.client.Minecraft.runTick(MinecraftAccessor.java:1784)
    at net.minecraft.client.Minecraft.runGameLoop(MinecraftAccessor.java:1078)
    at net.minecraft.client.Minecraft.run(MinecraftAccessor.java:8605)
    at net.minecraft.client.main.Main.main(SourceFile:123)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    at java.lang.reflect.Method.invoke(Method.java:580)
    at top.outlands.foundation.LaunchHandler.launch(LaunchHandler.java:121)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    at java.lang.reflect.Method.invoke(Method.java:580)
    at top.outlands.foundation.boot.Foundation.main(Foundation.java:41)

I've checked this and fixed it